### PR TITLE
Script colors via tput / terminfo

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -109,8 +109,8 @@ printy "Checking if Razer modules are present..."
 if [ ! -d "$razer_modules" ]; then
     echo "**************************************************"
     printr "The OpenRazer Python libraries are missing!"
-    echo -e "Please install them from \033[93mhttp://openrazer.github.io/\033[0m"
-    echo -e "They are expected to be installed here: \033[93m$razer_modules\033[0m"
+    echo "Please install them from ${yellow}http://openrazer.github.io${reset}"
+    echo "They are expected to be installed in ${yellow}$razer_modules${reset}"
     echo "**************************************************"
     read -p "Continue anyway? [y] " action
     if [ ! "$action" == 'y' ]; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -35,16 +35,27 @@ dependencies_apt="gir1.2-webkit2-4.0 python3-gi python3-setproctitle python3-req
 dependencies_pacman="webkitgtk python-gobject python-setproctitle python-requests libappindicator imagemagick nodejs-less"
 
 # Pretty colours!
+bold="$(tput bold)"
+black="$(tput setaf 0)"
+red="$(tput setaf 1)"
+green="$(tput setaf 2)"
+yellow="$(tput setaf 3)"
+blue="$(tput setaf 4)"
+magenta="$(tput setaf 5)"
+cyan="$(tput setaf 6)"
+white="$(tput setaf 7)"
+reset="$(tput sgr0)"
+
 function printg() {
-    echo -e "\033[92m$*\033[0m"
+    echo "${green}$*${reset}"
 }
 
 function printr() {
-    echo -e "\033[91m$*\033[0m"
+    echo "${red}$*${reset}"
 }
 
 function printy() {
-    echo -e "\033[93m$*\033[0m"
+    echo "${yellow}$*${reset}"
 }
 
 # Are we root?


### PR DESCRIPTION
Modern terminals support `terminfo` - a database of the capabilities of the terminal. This database is also capable of storing the colors supported by the current profile of the terminal.

This change uses the colors from the terminal's own color palette. This would make the colors match the current profile of the terminal.
This also means that we can do away with hard-coding ugly ANSI escape sequences for colors. All of that is automatically handled by `tput` via `terminfo`.

PS : I know we currently use only 3 colors (red, green and yellow), but I left the rest of the sequence for future capabilities.
Also, most terminals support another set of 'light' colors starting from colors 8 - 15 in the same order of 0 - 7