### PR TITLE
automate dependency installation

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -80,7 +80,7 @@ if [ "$distro" == "debian" ] || [ "$distro" == "ubuntu" ]; then
 elif [ "$distro" == "arch" ] || [ "$distro" == "manjaro" ]; then
     printy "Dependencies: $dependencies_pacman"
     read -p "Install dependencies with pacman? [y/n] | " choice
-    if [ "${choice,,}" == "y" ]; then
+    if [ "${choice,,}" == "y" ] || [ "${choice,,} == "yes" ]; then
         printg "Installing dependencies..."
         sudo pacman -Sy $dependencies_pacman
     fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -73,18 +73,18 @@ function get_distro() {
 distro=`get_distro`
 if [ "$distro" == "debian" ] || [ "$distro" == "ubuntu" ]; then
     printy "Dependencies: $dependencies_apt"
-    printg "Installing dependencies...\n"
-    sudo apt install $dependencies_apt
-    echo -e ''
+    printg "Installing dependencies..."
+    sudo apt install --yes $dependencies_apt
+    echo
 
 elif [ "$distro" == "arch" ] || [ "$distro" == "manjaro" ]; then
     printy "Dependencies: $dependencies_pacman"
     read -p "Install dependencies with pacman? [y/n] | " choice
-    if [ "$choice" == "y" ]; then
-        printg "Installing dependencies...\n"
-        sudo pacman -S $dependencies_pacman
+    if [ "${choice,,}" == "y" ]; then
+        printg "Installing dependencies..."
+        sudo pacman -Sy $dependencies_pacman
     fi
-    echo -e ''
+    echo
 
 else
     echo "**************************************************"


### PR DESCRIPTION
The current drive of the installation script allows the user the choice on whether or not to install the dependencies. The user can abort the installation midway via the prompt. Also, this requires manual intervention from the user for the installation to complete (I agree that is a always a good thing to have when installing packages system-wide).

This change will force and automate the dependency installation step in the installation process.

This change also enables Arch users to now pass `Y` / `YES` / `Yes` / `yes` as inputs to the `install with pacman?` prompt. The validation condition is now converted to lowercase during check.

PS : I've also made some other minor modifications too : 
* remove un-necessary escape-processing flag ( `-e` ) from empty `echo`
* remove un-necessary newline escape sequence (`echo` adds the newline character automatically, by default)