### PR TITLE
rudimentary fan control for Dev 1.0.0 pyqt5 

### DIFF
--- a/pylib/backends/openrazer.py
+++ b/pylib/backends/openrazer.py
@@ -904,7 +904,7 @@ class Backend(_backend.Backend):
         if not os.path.exists(device_images_dir):
             self.debug("Creating folder for device images: " + device_images_dir)
             os.makedirs(device_images_dir)
-
+        image_url = (image_url and image_url)  or ""
         image_path = os.path.join(device_images_dir, rdevice.name + "." + image_url.split(".")[-1])
 
         # Image already cached?

--- a/pylib/common.py
+++ b/pylib/common.py
@@ -154,9 +154,10 @@ def get_default_tray_icon():
         icon_value = "ui/img/tray/light/breeze.svg"
 
     # Unity/Ubuntu MATE
-    elif theme_env.startswith("Ambiant") or theme_env.startswith("Ambiance"):
+    elif (theme_env is not None) and (theme_env.startswith("Ambiant") or theme_env.startswith("Ambiance")):
         icon_value = "ui/img/tray/light/humanity.svg"
-
+    else: 
+        icon_value = "ui/img/tray/light/humanity.svg"
     return icon_value
 
 

--- a/pylib/locales.py
+++ b/pylib/locales.py
@@ -408,6 +408,10 @@ def get_strings():
         "revert_prompt_title": _("Revert Changes?"),
         "revert_prompt_text": _("All changes will be lost. Discard these modifications?"),
 
+        #Fan Control
+        "fan_speed" : _("Fan Speed"),
+        "fan_mode" : _("Fan Mode"),
+
         # End
         "": ""
     }


### PR DESCRIPTION
clearly shows that the set_fan_speed in RazerKeyboard should be @property, which was avoided since it is write_only
Apart form that, adding this new functions was easier than before

Non need to hurry with merging, depends on https://github.com/openrazer/openrazer/pull/1227