### PR TITLE
Add StartupWMClass

### DIFF
--- a/sources/launchers/polychromatic.desktop
+++ b/sources/launchers/polychromatic.desktop
@@ -14,6 +14,7 @@ Encoding=UTF-8
 Terminal=false
 Categories=Settings;HardwareSettings;
 Actions=devices;effects;tray-applet;
+StartupWMClass=polychromatic-controller
 #presets;triggers;
 
 [Desktop Action devices]


### PR DESCRIPTION
This is required to properly bind the application windows with panels or docks.

Without StartupWMClass:

![Snímek z 2021-10-08 01-07-15](https://user-images.githubusercontent.com/17854950/136474126-c591c817-3fb4-4a76-9f11-da419b9cfd88.png)

With StartupWMClass:

![Snímek z 2021-10-08 01-06-36](https://user-images.githubusercontent.com/17854950/136474141-2f9c614f-eef4-4255-84d3-c0beb77f663e.png)
