### PR TITLE
Change manpage about description of option device at polychromatic-cli

### DIFF
--- a/man/polychromatic-cli.1
+++ b/man/polychromatic-cli.1
@@ -30,7 +30,7 @@ Omitting these arguments selects all devices.\&
 .P
 \fB-d\fR, \fB--device\fR <ID>
 .RS 4
-Select the device(s) by form factor.\& Comma separated for multiple.\&
+Select the device by form factor.\&
 .P
 .RS 4
 .ie n \{\

--- a/man/polychromatic-cli.1.scd
+++ b/man/polychromatic-cli.1.scd
@@ -21,7 +21,7 @@ status information from connected hardware.
 	Omitting these arguments selects all devices.
 
 	*-d*, *--device* <ID>
-		Select the device(s) by form factor. Comma separated for multiple.
+		Select the device by form factor.
 
 		- accessory
 		- display

--- a/polychromatic-cli
+++ b/polychromatic-cli
@@ -199,7 +199,7 @@ if args.help:
     rows = [
         [
             dbg.action + "  -d, --device" + dbg.warning + " {id}",
-            dbg.normal + _("Select device(s) by form factor. If omitted, select all devices")
+            dbg.normal + _("Select the device by form factor. If omitted, use all devices")
         ],
         [
             "",


### PR DESCRIPTION
I changed the man page so that the behaviour of the script `polychromatic-cli` and man page is the same.
Correct #396 
I would appreciate it if you check this PR.