### PR TITLE
Add battery info to polychromatic-cli

### DIFF
--- a/polychromatic-cli
+++ b/polychromatic-cli
@@ -525,6 +525,21 @@ if args.list_options:
             col_param += " ({0}-{1})".format(details["dpi_min"], details["dpi_max"])
         _add_row()
 
+        if details["battery_level"]:
+            col_zone = dbg.grey + "-"
+            col_option = dbg.success + "battery_charging"
+            col_param = dbg.success
+            col_colours = dbg.grey + "-"
+            col_param += "{0}".format(details["battery_charging"])
+            _add_row()
+
+            col_zone = dbg.grey + "-"
+            col_option = dbg.success + "battery_level"
+            col_param = dbg.success
+            col_colours = dbg.grey + "-"
+            col_param += "{0}%".format(details["battery_level"])
+            _add_row()
+
         print_columns(rows, True)
 
 # After using a --list-* parameter, exit here as devices won't be manipulated.

--- a/pylib/backends/openrazer.py
+++ b/pylib/backends/openrazer.py
@@ -828,6 +828,8 @@ class Backend(_backend.Backend):
             "matrix": matrix,
             "matrix_rows": matrix_rows,
             "matrix_cols": matrix_cols,
+            "battery_charging": battery_charging,
+            "battery_level": battery_level,
             "zone_labels": zone_labels,
             "zone_icons": zone_icons,
             "zone_options": zone_options


### PR DESCRIPTION
## New feature
- print information about battery by polychromatic-cli

## Description
- change Backend so that the data is transferred to polcychomatic-cli
- print information about battery if it exists at polychromatic-cli

## Motivation 
I want to get the battery level by polychromatic-cli (not just GUI).

I don't understand the side effects and I haven't added any tests, so I'd like to know about that.