### PR TITLE
Edit openrazer config filepath.

### DIFF
--- a/polychromatic/controller/preferences.py
+++ b/polychromatic/controller/preferences.py
@@ -282,7 +282,7 @@ class OpenRazerPreferences(shared.TabData):
 
         self.conf_path = None
         try:
-            self.conf_path = "{0}/.config/openrazer/razer.conf".format(os.environ["XDG_CONFIG_HOME"])
+            self.conf_path = "{0}/openrazer/razer.conf".format(os.environ["XDG_CONFIG_HOME"])
         except KeyError:
             self.conf_path = "{0}/.config/openrazer/razer.conf".format(os.environ.get("HOME", "~"))
 


### PR DESCRIPTION
If XDG_CONFIG_HOME is properly set to $HOME/.config then the openrazer config filepath gets incorrectly set to
$HOME/.config/.config/openrazer/razer.conf