### PR TITLE
openrazer: Add support for upcoming 'on' effect

### DIFF
--- a/polychromatic/backends/openrazer.py
+++ b/polychromatic/backends/openrazer.py
@@ -755,8 +755,8 @@ class OpenRazerBackend(Backend):
                     self._persistence.save("effect", "none")
 
             option = NoneOption(rzone, zone._persistence)
-            option.label = self._("None")
-            option.icon = self.get_icon("options", "none")
+            option.label = self._("Off")
+            option.icon = self.get_icon("params", "0")
             options.append(option)
 
         if self._has_zone_capability(rdevice, zone, "on"):
@@ -776,7 +776,7 @@ class OpenRazerBackend(Backend):
 
             option = OnOption(rzone, zone._persistence)
             option.label = self._("On")
-            option.icon = self.get_icon("options", "on")
+            option.icon = self.get_icon("params", "100")
             options.append(option)
 
         if self._has_zone_capability(rdevice, zone, "spectrum"):

--- a/polychromatic/backends/openrazer.py
+++ b/polychromatic/backends/openrazer.py
@@ -759,6 +759,26 @@ class OpenRazerBackend(Backend):
             option.icon = self.get_icon("options", "none")
             options.append(option)
 
+        if self._has_zone_capability(rdevice, zone, "on"):
+            class OnOption(Backend.EffectOption):
+                def __init__(self, rzone, persistence):
+                    super().__init__()
+                    self._rzone = rzone
+                    self._persistence = persistence
+                    self.uid = "on"
+
+                def refresh(self):
+                    self.active = True if self._persistence.state["effect"] == "on" else False
+
+                def apply(self, param=None):
+                    self._rzone.on()
+                    self._persistence.save("effect", "on")
+
+            option = OnOption(rzone, zone._persistence)
+            option.label = self._("On")
+            option.icon = self.get_icon("options", "on")
+            options.append(option)
+
         if self._has_zone_capability(rdevice, zone, "spectrum"):
             class SpectrumOption(Backend.EffectOption):
                 def __init__(self, rzone, persistence):


### PR DESCRIPTION
This will be used on some devices instead of turning state on/off and will replace the mono-color static effect on others.

Testable with https://github.com/openrazer/openrazer/commits/next-on

--

TODO: Missing an icon, but I'm not a designer :upside_down_face: 