### PR TITLE
Fix the cynosa_v2_nordic.svg object structure

### DIFF
--- a/data/devicemaps/cynosa_v2_nordic.svg
+++ b/data/devicemaps/cynosa_v2_nordic.svg
@@ -273,11 +273,7 @@
            id="tspan4287"
            x="671.7832"
            style="font-size:8px;line-height:1.25"
-           y="257.11584"><tspan
-             id="tspan2255"
-             style="font-size:7.3333px">del</tspan><tspan
-             id="tspan2152"
-             style="font-size:6.1333px" /></tspan></text>
+           y="257.11584">del</tspan></text>
     </g>
     <g
        id="x16-y2"
@@ -2329,7 +2325,7 @@
            id="tspan261997"
            x="757.41962"
            y="67.239944"
-           style="stroke-width:0.398263">⏮&#xFE0E;</tspan></text>
+           style="stroke-width:0.398263">⏮︎</tspan></text>
     </g>
     <g
        id="x19-y0"
@@ -2349,7 +2345,7 @@
            id="tspan299874"
            x="789.57758"
            y="68.545204"
-           style="stroke-width:0.452113">⏯&#xFE0E;</tspan></text>
+           style="stroke-width:0.452113">⏯︎</tspan></text>
     </g>
     <g
        id="x20-y0"
@@ -2369,7 +2365,7 @@
            id="tspan336354"
            x="823.77563"
            y="67.239883"
-           style="stroke-width:0.398263">⏭&#xFE0E;</tspan></text>
+           style="stroke-width:0.398263">⏭︎</tspan></text>
     </g>
     <g
        id="x21-y0"
@@ -2389,7 +2385,7 @@
            id="tspan347871"
            x="853.09778"
            y="68.897362"
-           style="stroke-width:0.442755">🔇&#xFE0E;</tspan></text>
+           style="stroke-width:0.442755">🔇︎</tspan></text>
     </g>
     <g
        id="x17-y4"


### PR DESCRIPTION
Removed two extra tspan tags from the del key that caused warning

There were two extra tspan tags that caused the following warning messages when the file was loaded:
```
qt.svg: /polychromatic/data/devicemaps/cynosa_v2_nordic.svg:278:40: Could not add child element to parent element because the types are incorrect.
qt.svg: /polychromatic/data/devicemaps/cynosa_v2_nordic.svg:280:42: Could not add child element to parent element because the types are incorrect.
```

This was fixed previously in the cynosa_v2_en_US.svg file.