### PR TITLE
Fix the Wayland appId

### DIFF
--- a/polychromatic-controller
+++ b/polychromatic-controller
@@ -73,6 +73,9 @@ class ApplicationData(PolychromaticBase):
         # self.tab_triggers = None
         self.ui_preferences = None
 
+        # Set the Wayland appId to the name of the .desktop file (without the .desktop suffix)
+        self.main_app.setDesktopFileName("polychromatic")
+
         # Settings
         self.preferences = pref.load_file(self.paths.preferences)
         self.system_qt_theme = self.preferences["controller"]["system_qt_theme"]


### PR DESCRIPTION
Wayland compositors use the appId/desktopFileName window property to associate open windows to the correct .desktop launcher. By default Qt sets this to the name of the binary, which in the case of polychromatic was the binary name of Python. Set it to the correct value so that window associations are correct.