### PR TITLE
OpenRazer: Label brightness slider as Haptic intensity for Razer Nari Ultimate

### DIFF
--- a/polychromatic/backends/openrazer.py
+++ b/polychromatic/backends/openrazer.py
@@ -694,6 +694,14 @@ class OpenRazerBackend(Backend):
             slider = BrightnessSlider(rzone)
             slider.label = self._("Brightness")
             slider.icon = self.get_icon("options", "brightness")
+            # Device-specific label overrides for devices whose main-zone
+            # "brightness" actually controls something else. The Razer Nari
+            # Ultimate reuses the main-zone brightness slider for its haptic
+            # motor intensity. Only the main zone is overridden — the logo
+            # zone still controls the LED and keeps the default label.
+            if rdevice.name == "Razer Nari Ultimate" and zone.zone_id == "main":
+                slider.label = self._("Haptic intensity")
+                slider.uid = "haptic_intensity"
             return slider
 
         # Device uses an on/off state


### PR DESCRIPTION
Tiny device-specific override for the Razer Nari Ultimate.

## Context

A companion OpenRazer PR adds kernel driver and daemon support for the Razer Nari Ultimate (openrazer/openrazer#2772). The Nari Ultimate has bass-response haptic motors in the ear cups, but OpenRazer has no first-class "haptic" concept, so the driver reuses the standard `matrix_brightness` attribute as the 0..100 slider that drives the haptic motor intensity.

With that mapping in place, Polychromatic already auto-discovers the device and renders the main zone with a slider — but the slider label reads "Brightness", which is technically accurate as a magnitude and actively misleading as a name. The Nari has no addressable backlight; there is nothing on the device whose brightness the slider could be controlling, and users watching the slider move will feel vibration in their ears instead of seeing any visual change.

## Change

When the OpenRazer device name is exactly `Razer Nari Ultimate`, override the `BrightnessSlider` label from `"Brightness"` to `"Haptic intensity"` and change its `uid` from `brightness` to `haptic_intensity`. The backend plumbing underneath is unchanged — it still writes to `rzone.brightness` — this is purely a UI label override.

## Scope

Intentionally narrow:
- Only the Nari Ultimate (device name match). The non-Ultimate Nari has no haptic motors and its daemon class doesn't expose the brightness zone at all, so no override is needed there.
- Only the `BrightnessSlider` branch, not the `BrightnessToggle` branch below it. The Nari main zone always reports as a slider, never as a binary active toggle.
- No new dependency, no icon change, no change to effect rendering.

## Alternatives considered

- **A generic "haptic" feature in OpenRazer**. Long-term this is probably the right home — have the daemon expose `has("haptic_intensity")` as a first-class capability and let Polychromatic render it with its own icon and label. I'd happily follow up on that if the maintainers prefer. For now, keeping the change scoped to a single device name felt less risky than invasive backend changes.
- **A device name → label mapping table**. Slightly more extensible than an inline `if`, but overkill for a single device today. Easy to refactor into a dict if a second device ever needs the same override.

## Testing

Tested on Debian 13 / KDE Plasma 6 / PyQt6 6.9.0 / OpenRazer built from master with the companion PR applied, against a physical Razer Nari Ultimate Wireless (`1532:051a`). Before the change, Polychromatic displays "Brightness 50%". After the change, "Haptic intensity 50%". Moving the slider drives the physical haptic motors as expected (with audio playing over the Nari's USB audio interface, since the motors are reactive to bass).

## Credits

Companion work: openrazer/openrazer#2772, felixZmn/razer-nari-driver#2.
