### PR TITLE
Synchronize Apply to All Spectrum across devices

### DIFF
--- a/polychromatic-helper
+++ b/polychromatic-helper
@@ -158,16 +158,27 @@ class PolychromaticHelper(PolychromaticBase):
             self.dbg.stdout("Activating login trigger...", self.dbg.action, 1)
             print("stub:login trigger")
 
-        # -- Resume effect states (if any)
+        # -- Resume software-controlled lighting state (if any)
         if not login_trigger_set:
             procmgr = procpid.ProcessManager("helper")
-            for device_json in state_files:
-                serial = os.path.basename(device_json).replace(".json", "")
-                state = procpid.DeviceSoftwareState(serial)
-                effect = state.get_effect()
-                if effect:
-                    self.dbg.stdout("Resuming effect '{0}' on device serial '{1}'.".format(effect["name"], serial), self.dbg.action, 1)
-                    procmgr.start_component(["--run-fx", effect["path"], "--device-serial", serial])
+            global_state = procpid.GlobalSpectrumState()
+
+            if global_state.is_active():
+                self.dbg.stdout(
+                    "Resuming synchronized global Spectrum.",
+                    self.dbg.action,
+                    1
+                )
+                procmgr.start_component(["--run-global-spectrum"])
+
+            else:
+                for device_json in state_files:
+                    serial = os.path.basename(device_json).replace(".json", "")
+                    state = procpid.DeviceSoftwareState(serial)
+                    effect = state.get_effect()
+                    if effect:
+                        self.dbg.stdout("Resuming effect '{0}' on device serial '{1}'.".format(effect["name"], serial), self.dbg.action, 1)
+                        procmgr.start_component(["--run-fx", effect["path"], "--device-serial", serial])
 
         # Start Tray Applet
         if self.preferences["tray"]["autostart"]:

--- a/polychromatic-helper
+++ b/polychromatic-helper
@@ -30,6 +30,7 @@ be multple helper processes running simultaneously. It also is designed to be
 track alive or dead processes.
 """
 import argparse
+import colorsys
 import glob
 import setproctitle
 import os
@@ -65,6 +66,9 @@ class PolychromaticHelper(PolychromaticBase):
         elif self.args.monitor_triggers:
             self.monitor_triggers()
 
+        elif self.args.run_global_spectrum:
+            self.run_global_spectrum()
+
         elif self.args.run_fx and self.args.device_serial or self.args.device_name:
             self.run_fx(self.args.run_fx, self.args.device_name, self.args.device_serial)
 
@@ -85,6 +89,7 @@ class PolychromaticHelper(PolychromaticBase):
         parser.add_argument("--autostart", action="store_true")
         parser.add_argument("--monitor-triggers", action="store_true")
         parser.add_argument("--run-fx", action="store")
+        parser.add_argument("--run-global-spectrum", action="store_true")
 
         # Custom effects only
         parser.add_argument("-n", "--device-name", action="store")
@@ -186,6 +191,201 @@ class PolychromaticHelper(PolychromaticBase):
         This process should always be running when there is at least one trigger set.
         """
         print("stub:Helpers.monitor_triggers")
+
+    def run_global_spectrum(self):
+        """
+        Drive all compatible OpenRazer matrices from one software Spectrum
+        clock.
+
+        Custom mode is activated once at startup. During playback, only RGB
+        frame data is transmitted. Re-activating custom mode every frame can
+        cause visible flickering on some devices, including the Seiren V3
+        Chroma.
+        """
+        cycle_seconds = 10.0
+        fps = 20.0
+        frame_time = 1.0 / fps
+
+        process = procpid.ProcessManager("global-spectrum")
+        stop_requested = False
+
+        def stop_global_spectrum(signum, frame):
+            nonlocal stop_requested
+            stop_requested = True
+
+        signal.signal(signal.SIGUSR2, stop_global_spectrum)
+
+        devices = []
+
+        self.dbg.stdout(
+            "Preparing synchronized software Spectrum...",
+            self.dbg.action,
+            1
+        )
+
+        for device in self.middleman.get_devices():
+            matrix = device.matrix
+
+            if not matrix:
+                continue
+
+            try:
+                matrix.init()
+
+                rdevice = matrix._rdevice
+                advanced = rdevice.fx.advanced
+                lighting = advanced._lighting_dbus
+
+                devices.append({
+                    "device": device,
+                    "matrix": matrix,
+                    "advanced": advanced,
+                    "lighting": lighting,
+                })
+
+                self.dbg.stdout(
+                    "{0}: Added matrix ({1}x{2})".format(
+                        device.name,
+                        matrix.rows,
+                        matrix.cols
+                    ),
+                    self.dbg.success,
+                    1
+                )
+
+            except (AttributeError, NotImplementedError) as e:
+                self.dbg.stdout(
+                    "{0}: Global Spectrum unsupported: {1}".format(
+                        device.name,
+                        e
+                    ),
+                    self.dbg.warning,
+                    1
+                )
+
+        if not devices:
+            self.dbg.stdout(
+                "No compatible matrix devices were found.",
+                self.dbg.error
+            )
+            return
+
+        def set_colour(entry, red, green, blue):
+            matrix = entry["matrix"]
+
+            for y in range(matrix.rows):
+                for x in range(matrix.cols):
+                    matrix.set(
+                        x,
+                        y,
+                        red,
+                        green,
+                        blue
+                    )
+
+        def get_colour(timestamp, start):
+            elapsed = timestamp - start
+            hue = (elapsed / cycle_seconds) % 1.0
+
+            red_f, green_f, blue_f = colorsys.hsv_to_rgb(
+                hue,
+                1.0,
+                1.0
+            )
+
+            return (
+                round(red_f * 255),
+                round(green_f * 255),
+                round(blue_f * 255),
+            )
+
+        self.dbg.stdout(
+            "Preparing initial synchronized frame...",
+            self.dbg.action,
+            1
+        )
+
+        start = time.monotonic()
+        red, green, blue = get_colour(start, start)
+
+        # Fill every local matrix before transmitting anything.
+        for entry in devices:
+            set_colour(
+                entry,
+                red,
+                green,
+                blue
+            )
+
+        # Send the initial frame to every device.
+        for entry in devices:
+            entry["lighting"].setKeyRow(
+                bytes(entry["advanced"].matrix)
+            )
+
+        # IMPORTANT:
+        #
+        # Activate custom mode exactly once. The normal OpenRazer
+        # advanced.draw() path calls setCustom() after every frame. That
+        # produces visible flickering on the Seiren V3 Chroma when used for
+        # continuous software rendering.
+        self.dbg.stdout(
+            "Activating custom mode...",
+            self.dbg.action,
+            1
+        )
+
+        for entry in devices:
+            entry["lighting"].setCustom()
+
+        self.dbg.stdout(
+            "Synchronizing {0} device(s) at {1:.0f} FPS.".format(
+                len(devices),
+                fps
+            ),
+            self.dbg.success,
+            1
+        )
+
+        process.set_component_pid()
+
+        try:
+            while not stop_requested:
+                frame_start = time.monotonic()
+
+                # ONE master colour calculated from ONE clock.
+                red, green, blue = get_colour(
+                    frame_start,
+                    start
+                )
+
+                # Update every local matrix first.
+                for entry in devices:
+                    set_colour(
+                        entry,
+                        red,
+                        green,
+                        blue
+                    )
+
+                # FRAME DATA ONLY.
+                #
+                # Do not call matrix.draw() or advanced.draw() here because
+                # those paths also re-issue the custom-effect activation
+                # command.
+                for entry in devices:
+                    entry["lighting"].setKeyRow(
+                        bytes(entry["advanced"].matrix)
+                    )
+
+                elapsed = time.monotonic() - frame_start
+                remaining = frame_time - elapsed
+
+                if remaining > 0:
+                    time.sleep(remaining)
+
+        finally:
+            process.release_component_pid()
 
     def run_fx(self, path, name, serial):
         """

--- a/polychromatic/bulkapply.py
+++ b/polychromatic/bulkapply.py
@@ -6,6 +6,7 @@ Handles the bulk "Apply to All" options to apply settings to all devices at once
 from . import common
 from . import middleman as mn
 from . import preferences
+from . import procpid
 from .backends._backend import Backend
 
 
@@ -37,6 +38,19 @@ class _BulkBrightness(BulkOption):
 class _BulkEffect(BulkOption):
     def apply(self, a=None):
         # 'a' is an object passed from Tray Applet. Unnecessary.
+
+        # Stop any per-device software effects before changing the lighting
+        # state of all devices.
+        for device in self.middleman.get_devices():
+            self.middleman.stop_software_effect(device.serial)
+
+        # Apply to All -> Spectrum uses one shared software clock rather than
+        # starting each device's independent hardware Spectrum effect.
+        if self.value == "spectrum":
+            process = procpid.ProcessManager("helper")
+            process.start_component(["--run-global-spectrum"])
+            return
+
         for option in self.options:
             if not option.uid == self.value:
                 continue

--- a/polychromatic/bulkapply.py
+++ b/polychromatic/bulkapply.py
@@ -47,8 +47,13 @@ class _BulkEffect(BulkOption):
         # Apply to All -> Spectrum uses one shared software clock rather than
         # starting each device's independent hardware Spectrum effect.
         if self.value == "spectrum":
+            state = procpid.GlobalSpectrumState()
+            state.set_active()
+
             process = procpid.ProcessManager("helper")
-            process.start_component(["--run-global-spectrum"])
+            if not process.start_component(["--run-global-spectrum"]):
+                state.clear_active()
+
             return
 
         for option in self.options:

--- a/polychromatic/middleman.py
+++ b/polychromatic/middleman.py
@@ -360,6 +360,10 @@ class Middleman(object):
         Prior to applying a hardware effect, make sure any software effects
         have stopped.
         """
+        global_process = procpid.ProcessManager("global-spectrum")
+        if global_process.is_another_instance_is_running():
+            global_process.stop()
+
         process = procpid.ProcessManager(serial)
         state = procpid.DeviceSoftwareState(serial)
 

--- a/polychromatic/middleman.py
+++ b/polychromatic/middleman.py
@@ -360,6 +360,9 @@ class Middleman(object):
         Prior to applying a hardware effect, make sure any software effects
         have stopped.
         """
+        global_state = procpid.GlobalSpectrumState()
+        global_state.clear_active()
+
         global_process = procpid.ProcessManager("global-spectrum")
         if global_process.is_another_instance_is_running():
             global_process.stop()

--- a/polychromatic/procpid.py
+++ b/polychromatic/procpid.py
@@ -248,6 +248,50 @@ class ProcessManager():
             procmgr.reload(pid_file)
 
 
+class GlobalSpectrumState(object):
+    """
+    Tracks whether synchronized Apply to All Spectrum should be restored
+    automatically at login.
+
+    This state is global rather than tied to a device serial, so it is stored
+    outside the per-device states directory.
+    """
+    def __init__(self):
+        self.state_path = os.path.join(
+            common.paths.config,
+            "global-spectrum.json"
+        )
+
+    def is_active(self):
+        """
+        Return True when synchronized global Spectrum should be restored.
+        """
+        if not os.path.exists(self.state_path):
+            return False
+
+        try:
+            with open(self.state_path) as f:
+                state = json.load(f)
+            return bool(state.get("active", False))
+        except Exception:
+            print("Ignoring bad data: ", self.state_path)
+            return False
+
+    def set_active(self):
+        """
+        Remember that synchronized global Spectrum is the desired state.
+        """
+        with open(self.state_path, "w") as f:
+            f.write(json.dumps({"active": True}))
+
+    def clear_active(self):
+        """
+        Stop restoring synchronized global Spectrum at future logins.
+        """
+        if os.path.exists(self.state_path):
+            os.remove(self.state_path)
+
+
 class DeviceSoftwareState(object):
     """
     Tracks the active custom software effect or preset for a specified device,


### PR DESCRIPTION
## Summary

Makes **Apply to All → Spectrum** use a shared software-rendered Spectrum effect so compatible RGB devices stay synchronized.

Previously, Apply to All invoked each device's native hardware Spectrum effect sequentially. Because those effects run from independent device/firmware clocks, devices can start slightly out of phase and drift relative to one another.

This change:

* adds a `--run-global-spectrum` mode to `polychromatic-helper`
* uses one `time.monotonic()` clock and one Spectrum colour per frame for all compatible matrices
* runs the synchronized renderer at 20 FPS with a 10-second Spectrum cycle
* activates custom mode once at startup, then sends frame-only matrix updates during playback
* uses `ProcessManager("global-spectrum")` for clean start/stop lifecycle management
* stops per-device software effects before starting the global Spectrum renderer
* stops the global Spectrum renderer when another hardware effect is applied
* only changes **Apply to All → Spectrum**; individual-device Spectrum continues to use the normal native hardware effect

The frame-only update path is intentional. Re-activating custom mode on every frame can cause visible flickering on some devices, while setting custom mode once and subsequently transmitting only RGB frame data provides smooth continuous playback.

## Testing

Tested locally with OpenRazer using:

* Razer Seiren V3 Chroma — 1×10 matrix
* Razer Goliathus Extended — 1×1 matrix
* Razer Basilisk V3 — 1×11 matrix
* Razer Huntsman V3 Pro 8KHz — 6×22 matrix
* Razer Nommo Chroma — 2×24 matrix

All five devices remained visually synchronized with no visible drift, stutter, or Seiren flickering.

A 45-second renderer test at 20 FPS completed 898 frames with:

* 0 frame overruns
* 24.38 ms worst observed frame time
* 50 ms frame budget

Also tested:

* Apply to All → Spectrum
* Spectrum → Static
* Spectrum → parameterized hardware effects
* repeated Spectrum activation
* rapid Spectrum / Static switching
* Controller close while Spectrum continues running
* Controller reopen followed by stopping Spectrum
* clean PID removal through `SIGUSR2`
* no orphan `polychromatic-helper` processes
* installed-package overlay using the normal Polychromatic Controller
* `git diff --check`
* Python syntax compilation

The synchronized renderer is intentionally limited to the bulk Spectrum action so normal per-device hardware effect behavior remains unchanged.

## Login restoration

The synchronized global Spectrum state is persisted so it can be restored automatically when the user's session starts.

When **Apply to All → Spectrum** is selected, Polychromatic records that global Spectrum is the desired lighting state. During the normal `polychromatic-helper --autostart` sequence, after the backends are available, the helper checks this state and restarts the synchronized Spectrum renderer.

Selecting another hardware effect clears the persisted global Spectrum state, so Spectrum is only restored at the next login if it was intentionally left active.

This was tested both by manually invoking the normal `--autostart` path and with a full system reboot.

Full reboot test:

* synchronized Spectrum was active before reboot
* persistent state survived the reboot
* `polychromatic-helper --autostart` automatically started the global Spectrum renderer after login
* a new `global-spectrum.pid` was created and the renderer process was alive
* all tested devices resumed synchronized Spectrum without opening the Controller
* switching from Spectrum to Static removed the PID, stopped the helper, and cleared the persistent state as expected

