### PR TITLE
locales: look for catalogues outside the interpreter's prefix

### DIFF
--- a/polychromatic/locales.py
+++ b/polychromatic/locales.py
@@ -12,6 +12,12 @@ class Locales(object):
     Supports localisation throughout the application by utilising gettext.
     The "_" object is used for processing strings.
     """
+    locale_dirs = [
+        "/usr/local/share/locale",
+        "/usr/share/locale",
+        "/app/share/locale",
+    ]
+
     def __init__(self, force_locale=""):
         self.force_locale = force_locale
         self.locale = force_locale
@@ -25,23 +31,39 @@ class Locales(object):
         Returns:
             gettext.translation() bound to an i18n variable.
         """
-        is_relative = os.path.exists(os.path.join(os.path.dirname(__file__), "..", "data", "img"))
-        relative_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "locale/"))
+        languages = [self.locale] if self.force_locale else None
 
-        # For development or a standalone "opt" build
-        if is_relative and self.force_locale:
-            self.translation = gettext.translation("polychromatic", localedir=relative_path, fallback=True, languages=[self.locale])
-        elif is_relative:
-            self.translation = gettext.translation("polychromatic", localedir=relative_path, fallback=True)
-
-        # For packaged/system-wide installs
-        elif not is_relative and self.force_locale:
-            self.translation = gettext.translation("polychromatic", fallback=True, languages=[self.locale])
-        else:
-            self.translation = gettext.translation("polychromatic", fallback=True)
+        self.translation = gettext.translation("polychromatic",
+                                               localedir=self.get_locale_path(languages),
+                                               languages=languages,
+                                               fallback=True)
 
         self._ = self.translation.gettext
         return self._
+
+    def get_locale_path(self, languages=None):
+        """
+        Returns the directory holding the message catalogues, or None to leave
+        gettext to its own default.
+
+        For packaged installs, gettext derives its default from the Python
+        interpreter's prefix, which is only the application's prefix when the
+        two are installed together. Inside a Flatpak they are not: the
+        application is under /app while the interpreter comes from the runtime's
+        /usr, so every translation goes unused unless the directory is named.
+        """
+        module_path = __file__
+
+        # For development or a standalone "opt" build
+        if os.path.exists(os.path.join(os.path.dirname(module_path), "../data/img/")):
+            return os.path.abspath(os.path.join(os.path.dirname(module_path), "../locale/"))
+
+        # For packaged/system-wide installs
+        for directory in self.locale_dirs:
+            if gettext.find("polychromatic", directory, languages):
+                return directory
+
+        return None
 
     def get_current_locale(self):
         """

--- a/tests/internals.py
+++ b/tests/internals.py
@@ -32,6 +32,11 @@ class TestInternals(unittest.TestCase):
         _ = i18n.init()
         self.assertEqual(i18n.get_current_locale(), "de", "Could not set up a German locale")
 
+    def test_locales_path_can_be_found(self):
+        i18n = locales.Locales("de")
+        expected = os.path.abspath(os.path.join(os.path.dirname(locales.__file__), "..", "locale"))
+        self.assertEqual(i18n.get_locale_path(["de"]), expected, "Could not locate the message catalogues")
+
     def test_locales_can_translate_strings(self):
         _ = locales.Locales("de").init()
         # EN: Breath | DE: Atem


### PR DESCRIPTION
In the Flathub build (`app.polychromatic.controller` 0.9.8) the interface is always English, whatever the locale is set to. The same version installed from a distribution package, on the same machine and in the same session, is translated.

### Why

For packaged installs `Locales.init()` calls `gettext.translation()` without a `localedir`, so gettext falls back to its own default, which is derived from the *Python interpreter's* prefix rather than the application's. Inside a Flatpak those are not the same prefix: the application is installed under `/app`, while the interpreter comes from the runtime's `/usr`. gettext therefore looks under `/usr/share/locale`, where the application has installed nothing.

Measured inside the sandbox:

```
$ flatpak run --command=python3 app.polychromatic.controller -c \
    'import sys, gettext; print(sys.base_prefix); print(gettext._default_localedir); \
     print(gettext.find("polychromatic")); print(gettext.find("polychromatic", "/app/share/locale"))'
/usr
/usr/share/locale
None
/app/share/locale/ru_RU/LC_MESSAGES/polychromatic.mo
```

The catalogue is installed, readable and valid -- it is simply never looked for.

### Scope

This affects every translation the project ships, not one language, and there is nothing a user can set to work around it:

* `--locale <lang>` does not help -- the packaged branch omits `localedir` there as well;
* `LANGUAGE` / `LC_ALL` do not help either, because the search path is wrong rather than the language:

```
$ flatpak run --env=LANGUAGE=ru --command=python3 app.polychromatic.controller -c \
    'import gettext; print(gettext.find("polychromatic"))'
None
```

### The change

`Paths.get_data_path()` already searches `/usr/local/share/polychromatic`, `/usr/share/polychromatic` and `/app/share/polychromatic`. This does the same for the message catalogues, and leaves gettext to its own default when the domain is not found in any of them -- so nothing changes for installs where the default was already correct.

Measured with the module swapped into the 0.9.8 Flatpak (`LANG=ru_RU.UTF-8`, no flags):

| | `get_current_locale()` | `_("Devices")` |
|---|---|---|
| before | `en_GB` | `Devices` |
| after | `ru` | `Устройства` |

The same swap against the distribution package still reports `ru` / `Устройства`, so the system-wide path is unaffected. `./tests/run.sh` passes (49 tests), including a new one covering the lookup.

### Side note for the Flathub packaging

The Locale extension for 0.9.8 carries the catalogues under their pre-4378f58 names (`ru_RU`, `de_DE`); a rebuild on current `master` will install them as `ru`, `de` and so on. Both are found by this change.
