### PR TITLE
Russian: use "FPS" for the effect editor playback speed

### DIFF
--- a/locale/ru.po
+++ b/locale/ru.po
@@ -398,7 +398,7 @@ msgstr "Кадров в секунду для воспроизведения п�
 
 #: editor.ui.h:70
 msgid "fps"
-msgstr "к/с"
+msgstr "FPS"
 
 #: editor.ui.h:71
 msgid "Current Colour"


### PR DESCRIPTION
One string in `locale/ru.po`: the `fps` suffix of the playback speed spinner in the effect editor.

It was translated as "к/с". That is a legitimate Russian abbreviation for "frames per second", but this spinner sits in a lighting/gaming tool, and "FPS" is the form Russian-speaking gamers actually use — "к/с" needs a moment to unpack. The tooltip on the very same spinner already says "Кадров в секунду..." in full, so no meaning is lost by keeping the short form in Latin.

It also lines up with the rest of the catalogues — fr, nl, pl, zh_CN and zh_TW all keep `fps` here.

`msgfmt --check` passes, 724 messages, no fuzzy entries.

While I was in there I went over the rest of `ru.po` looking for Razer names that should not have been translated at all. I did not find any worth changing: the effect names (Wave, Spectrum, Breath, Starlight, Ripple...), the zone names and the scroll modes are all translated in Razer's own Russian manuals too, and the acronyms (DPI, RGB, LED, DKMS) are already left alone. So this stays a one-line change.

Unrelated to #606 — separate branch off master on purpose.