### PR TITLE
launchers: add Russian keywords to the desktop entry

### DIFF
--- a/sources/launchers/polychromatic.desktop
+++ b/sources/launchers/polychromatic.desktop
@@ -25,6 +25,7 @@ Categories=Settings;HardwareSettings;
 Actions=devices;effects;tray-applet;
 StartupWMClass=polychromatic-controller
 Keywords=RGB;Razer;Chroma;
+Keywords[ru]=RGB;Razer;Chroma;OpenRazer;подсветка;освещение;свет;цвет;эффекты;клавиатура;мышь;коврик;периферия;устройства;
 #presets;triggers;
 
 [Desktop Action devices]


### PR DESCRIPTION
The desktop entry is already fully translated into Russian — name, comment and
all three actions — but `Keywords` is English only. That is the one line the
menu search actually looks at, so on a Russian desktop typing "подсветка" or
"клавиатура" finds nothing, and you have to know the product name to launch it.

So this adds one line:

    Keywords[ru]=RGB;Razer;Chroma;OpenRazer;подсветка;освещение;свет;цвет;эффекты;клавиатура;мышь;коврик;периферия;устройства;

The product and standard names stay in Latin on purpose (RGB, Razer, Chroma,
OpenRazer) — that is how people type them, transliterating would only hurt.

Checked with `desktop-file-validate` (clean), and by reading the entry through
`Gio.DesktopAppInfo`: under `LANG=ru_RU.UTF-8` the keyword list comes back
Russian, under `LANG=C` it is still the old `RGB;Razer;Chroma`, so nothing
changes for anyone else.

No other language has a Keywords line yet, so I only did the one I can vouch
for. If you want, the same trick works for de/fr/nl/pt_BR/zh_CN/pl_PL whenever
those translators are around.
