### PR TITLE
Controller: add a language option to the preferences

### DIFF
--- a/data/qt/preferences.ui
+++ b/data/qt/preferences.ui
@@ -83,6 +83,25 @@
             <number>10</number>
            </property>
            <item row="0" column="0">
+            <widget class="QLabel" name="LanguageLabel">
+             <property name="minimumSize">
+              <size>
+               <width>150</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string extracomment="Preferences Label">Language</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="LanguageCombo"/>
+           </item>
+           <item row="1" column="0">
             <widget class="QLabel" name="AppearanceLabel">
              <property name="minimumSize">
               <size>
@@ -98,7 +117,7 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="1" column="1">
             <widget class="QWidget" name="UseSystemQtThemeGroup" native="true">
              <layout class="QVBoxLayout" name="UseSystemQtThemeGroup_Layout">
               <property name="spacing">
@@ -148,7 +167,7 @@
              </layout>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="2" column="1">
             <widget class="QWidget" name="AlwaysHideMenuBarGroup" native="true">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -204,7 +223,7 @@
              </layout>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="3" column="0">
             <widget class="QLabel" name="DevicesLabel">
              <property name="minimumSize">
               <size>
@@ -217,7 +236,7 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="3" column="1">
             <widget class="QWidget" name="DownloadDeviceImagesGroup" native="true">
              <layout class="QVBoxLayout" name="DownloadDeviceImagesGroup_Layout">
               <property name="spacing">
@@ -267,7 +286,7 @@
              </layout>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="4" column="0">
             <widget class="QLabel" name="ToolbarStyleLabel">
              <property name="minimumSize">
               <size>
@@ -283,7 +302,7 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
+           <item row="4" column="1">
             <widget class="QComboBox" name="ToolbarStyle">
              <item>
               <property name="text">
@@ -312,7 +331,7 @@
              </item>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="5" column="0">
             <widget class="QLabel" name="LandingTabLabel">
              <property name="minimumSize">
               <size>
@@ -325,7 +344,7 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
+           <item row="5" column="1">
             <widget class="QComboBox" name="LandingTabCombo">
              <item>
               <property name="text">
@@ -365,7 +384,7 @@
              </item>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="6" column="0">
             <widget class="QLabel" name="WindowBehaviourLabel">
              <property name="minimumSize">
               <size>
@@ -378,7 +397,7 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="1">
+           <item row="6" column="1">
             <widget class="QComboBox" name="WindowBehaviourCombo">
              <property name="currentText">
               <string>Always open in the center</string>

--- a/polychromatic/base.py
+++ b/polychromatic/base.py
@@ -36,6 +36,11 @@ class PolychromaticBase(object):
     pref.init(_)
     preferences = pref.load_file(paths.preferences)
 
+    # A language set in the preferences takes priority over the system's
+    if preferences["controller"]["language"]:
+        i18n = Locales(preferences["controller"]["language"])
+        _ = i18n.init()
+
     # Devices
     middleman = Middleman()
 

--- a/polychromatic/controller/preferences.py
+++ b/polychromatic/controller/preferences.py
@@ -6,7 +6,9 @@ This module controls the 'Preferences' window of the Controller GUI.
 
 import configparser
 import os
+import unicodedata
 
+from PyQt6.QtCore import QLocale
 from PyQt6.QtGui import QAction, QIcon
 from PyQt6.QtWidgets import (QCheckBox, QComboBox, QDialog, QDialogButtonBox,
                              QDoubleSpinBox, QLabel, QMessageBox, QPushButton,
@@ -87,6 +89,8 @@ class PreferencesWindow(shared.TabData):
         for option in self.options:
             self._load_option(option[0], option[1], option[2], option[3], option[4])
 
+        self._load_languages()
+
         self.dialog.findChild(QPushButton, "SavedColoursButton").clicked.connect(self.modify_colours)
         self.dialog.findChild(QPushButton, "SavedColoursReset").clicked.connect(self.reset_colours)
 
@@ -111,6 +115,7 @@ class PreferencesWindow(shared.TabData):
             self.prompt_restart = True
 
         self.dialog.findChild(QCheckBox, "UseSystemQtTheme").stateChanged.connect(_cb_set_restart_flag)
+        self.dialog.findChild(QComboBox, "LanguageCombo").currentIndexChanged.connect(_cb_set_restart_flag)
 
         # Restart the tray applet after changing these options
         def _cb_set_applet_flag(i):
@@ -153,6 +158,43 @@ class PreferencesWindow(shared.TabData):
         # Show time!
         self.dialog.findChild(QTabWidget, "PreferencesTabs").setCurrentIndex(open_tab if open_tab else 0)
         self.dialog.open()
+
+    def _load_languages(self):
+        """
+        Populates the language dropdown with the languages installed on this
+        system, under their own native name.
+        """
+        combo = self.dialog.findChild(QComboBox, "LanguageCombo")
+        languages = []
+
+        for code in self.i18n.get_installed_languages():
+            name = QLocale(code).nativeLanguageName()
+
+            # Qt doesn't know this language, show the code as-is
+            if not name:
+                languages.append([code, code])
+                continue
+
+            # Some names come back in lowercase, but capitalising them is only
+            # correct for scripts that use case in running text.
+            if unicodedata.name(name[0], "").split(" ")[0] in ["LATIN", "CYRILLIC", "GREEK"]:
+                name = name[0].upper() + name[1:]
+
+            languages.append([name, code])
+
+        # Qt tells some languages apart by name already ("British English"), so
+        # only add the country when two entries would otherwise read the same.
+        names = [language[0] for language in languages]
+        for language in languages:
+            if names.count(language[0]) > 1:
+                language[0] = "{0} ({1})".format(language[0], QLocale(language[1]).nativeTerritoryName())
+
+        combo.addItem(self._("Follow System Language"), "")
+        for name, code in sorted(languages):
+            combo.addItem(name, code)
+
+        index = combo.findData(self.pref_data["controller"]["language"])
+        combo.setCurrentIndex(index if index >= 0 else 0)
 
     def _load_option(self, group, item, qcontrol, qid, inverted):
         """
@@ -204,6 +246,10 @@ class PreferencesWindow(shared.TabData):
         self.dbg.stdout("Saving preferences...", self.dbg.action, 1)
         for option in self.options:
             self._set_option(option[0], option[1], option[2], option[3], option[4])
+
+        language = self.dialog.findChild(QComboBox, "LanguageCombo").currentData()
+        self.pref_data["controller"]["language"] = language
+        self.appdata.preferences["controller"]["language"] = language
 
         result = pref.save_file(self.paths.preferences, self.pref_data)
         if result:

--- a/polychromatic/locales.py
+++ b/polychromatic/locales.py
@@ -41,6 +41,42 @@ class Locales(object):
         self._ = self.translation.gettext
         return self._
 
+    def get_installed_languages(self):
+        """
+        Returns a sorted list of language codes that have a message catalogue
+        present on this system, e.g. ["de", "fr", "ru"].
+
+        Users may remove languages they don't need, so the catalogues on disk
+        are the source of truth, not the LINGUAS file at build time.
+        """
+        found = ["en_GB"]
+        relative_path = self._get_relative_path()
+        directories = [relative_path] if relative_path else self.locale_dirs
+
+        for directory in directories:
+            try:
+                names = os.listdir(directory)
+            except OSError:
+                continue
+
+            for name in names:
+                if os.path.exists(os.path.join(directory, name, "LC_MESSAGES", "polychromatic.mo")):
+                    found.append(name)
+
+        return sorted(set(found))
+
+    def _get_relative_path(self):
+        """
+        Returns the locale directory for a development or standalone "opt"
+        build, or None when the application is installed system-wide.
+        """
+        module_path = os.path.dirname(__file__)
+
+        if os.path.exists(os.path.join(module_path, "../data/img/")):
+            return os.path.abspath(os.path.join(module_path, "../locale/"))
+
+        return None
+
     def get_locale_path(self, languages=None):
         """
         Returns the directory holding the message catalogues, or None to leave
@@ -52,11 +88,10 @@ class Locales(object):
         application is under /app while the interpreter comes from the runtime's
         /usr, so every translation goes unused unless the directory is named.
         """
-        module_path = __file__
-
         # For development or a standalone "opt" build
-        if os.path.exists(os.path.join(os.path.dirname(module_path), "../data/img/")):
-            return os.path.abspath(os.path.join(os.path.dirname(module_path), "../locale/"))
+        relative_path = self._get_relative_path()
+        if relative_path:
+            return relative_path
 
         # For packaged/system-wide installs
         for directory in self.locale_dirs:

--- a/polychromatic/preferences.py
+++ b/polychromatic/preferences.py
@@ -85,6 +85,7 @@ def load_file(filepath):
         _validate("editor", "system_cursors", bool, False)
         _validate("editor", "suppress_confirm_dialog", bool, False)
         _validate("editor", "show_saved_colour_shades", bool, True)
+        _validate("controller", "language", str, "")
         _validate("controller", "download_device_images", bool, True)
         _validate("controller", "landing_tab", int, 0)
         _validate("controller", "show_menu_bar", bool, True)

--- a/tests/internals.py
+++ b/tests/internals.py
@@ -37,6 +37,10 @@ class TestInternals(unittest.TestCase):
         expected = os.path.abspath(os.path.join(os.path.dirname(locales.__file__), "..", "locale"))
         self.assertEqual(i18n.get_locale_path(["de"]), expected, "Could not locate the message catalogues")
 
+    def test_locales_installed_can_be_listed(self):
+        i18n = locales.Locales()
+        self.assertIn("de", i18n.get_installed_languages(), "Could not list the installed languages")
+
     def test_locales_can_translate_strings(self):
         _ = locales.Locales("de").init()
         # EN: Breath | DE: Atem


### PR DESCRIPTION
Closes #604. The dropdown sits above Appearance and lists only the languages that have a catalogue on disk (the scan reuses the paths from #605), under their native name from `QLocale`. Left on "Follow System Language" nothing changes; picking one overrides the system language and, like the system theme option, asks for a restart.

Tried it with the dev copy on Arch in an `en_GB` session: switched to German, then Russian, then back to following the system, and the interface came back in each language after the restart. Removing `nl`, `pl` and `zh_TW` from the locale directory dropped them from the list.

One thing I'm unsure about: Qt returns "British English" and "American English" rather than "English (United Kingdom)", so I only append the country when two entries would otherwise read the same. Easy to change if you'd rather always show it.
